### PR TITLE
FEAT(alt1-plugin): show not-connected prompt when session is disconnected

### DIFF
--- a/alt1-plugin/src/App.tsx
+++ b/alt1-plugin/src/App.tsx
@@ -13,6 +13,7 @@ import { PostSpawnForm } from './components/PostSpawnForm';
 import { DeadForm } from './components/DeadForm';
 import { TooltipProvider } from './components/ui/tooltip';
 import { DebugPanel } from './components/DebugPanel';
+import { NotConnectedPrompt } from './components/NotConnectedPrompt';
 import type { TreeType } from '@shared/types';
 import type { ClientMessage } from '@shared/protocol';
 
@@ -805,101 +806,107 @@ export function App() {
 
         <hr className="border-t border-border" />
 
-        <WorldInput
-          world={world}
-          hasPixel={hasPixel}
-          hasGameState={hasGameState}
-          autoWorld={autoWorld}
-          isWorldScanning={isWorldScanning}
-          onChange={(v) => { setWorld(v); }}
-          onScan={handleScanWorld}
-          onAutoWorldToggle={() => {
-            setAutoWorld(s => {
-              if (!s) {
-                // Test gamestate access before enabling
-                const result = scanWorld();
-                if (!result) {
-                  showStatus('Could not detect world. Right click on "Alt1 Toolkit," then enable "Show current world."', 'warn');
-                  return false;
-                }
-                setWorld(String(result.world));
-                showStatus(`World ${result.world} detected. Auto-detect on.`, 'ok');
-              } else {
-                clearStatus();
-              }
-              const next = !s;
-              localStorage.setItem('scout_autoWorld', String(next));
-              return next;
-            });
-          }}
-        />
+        {status === 'connected' ? (
+          <>
+            <WorldInput
+              world={world}
+              hasPixel={hasPixel}
+              hasGameState={hasGameState}
+              autoWorld={autoWorld}
+              isWorldScanning={isWorldScanning}
+              onChange={(v) => { setWorld(v); }}
+              onScan={handleScanWorld}
+              onAutoWorldToggle={() => {
+                setAutoWorld(s => {
+                  if (!s) {
+                    // Test gamestate access before enabling
+                    const result = scanWorld();
+                    if (!result) {
+                      showStatus('Could not detect world. Right click on "Alt1 Toolkit," then enable "Show current world."', 'warn');
+                      return false;
+                    }
+                    setWorld(String(result.world));
+                    showStatus(`World ${result.world} detected. Auto-detect on.`, 'ok');
+                  } else {
+                    clearStatus();
+                  }
+                  const next = !s;
+                  localStorage.setItem('scout_autoWorld', String(next));
+                  return next;
+                });
+              }}
+            />
 
-        <ModeNav mode={mode} onChange={swapMode} />
+            <ModeNav mode={mode} onChange={swapMode} />
 
-        {mode === 'postspawn' ? (
-          <PostSpawnForm
-            treeType={treeType}
-            exactLocation={exactLocation}
-            hint={hint}
-            statusMsg={statusMsg}
-            statusKind={statusKind}
-            hasPixel={hasPixel}
-            canSubmit={canSubmit}
-            onTreeTypeChange={setTreeType}
-            onExactLocationChange={handleExactLocationChange}
-            onHintChange={handleHintChange}
-            autoScan={autoScan}
-            isScanning={isScanning}
-            onScanDialog={handleScanDialog}
-            onAutoScanToggle={handleAutoScanToggle}
-            autoSubmit={autoSubmit}
-            autoCountdown={autoCountdown}
-            cloudCheck={cloudCheck}
-            blinkFrame={blinkFrame}
-            onAutoSubmitToggle={handleAutoSubmitToggle}
-            onSubmit={handleSubmit}
-            onClear={handleClear}
-          />
-        ) : mode === 'dead' ? (
-          <DeadForm
-            statusMsg={statusMsg}
-            statusKind={statusKind}
-            canSubmit={canSubmit}
-            hint={hint}
-            exactLocation={exactLocation}
-            autoSubmit={autoSubmit}
-            autoCountdown={autoCountdown}
-            cloudCheck={cloudCheck}
-            blinkFrame={blinkFrame}
-            onHintChange={handleHintChange}
-            onAutoSubmitToggle={handleAutoSubmitToggle}
-            onSubmit={handleSubmit}
-            onClear={handleClear}
-          />
+            {mode === 'postspawn' ? (
+              <PostSpawnForm
+                treeType={treeType}
+                exactLocation={exactLocation}
+                hint={hint}
+                statusMsg={statusMsg}
+                statusKind={statusKind}
+                hasPixel={hasPixel}
+                canSubmit={canSubmit}
+                onTreeTypeChange={setTreeType}
+                onExactLocationChange={handleExactLocationChange}
+                onHintChange={handleHintChange}
+                autoScan={autoScan}
+                isScanning={isScanning}
+                onScanDialog={handleScanDialog}
+                onAutoScanToggle={handleAutoScanToggle}
+                autoSubmit={autoSubmit}
+                autoCountdown={autoCountdown}
+                cloudCheck={cloudCheck}
+                blinkFrame={blinkFrame}
+                onAutoSubmitToggle={handleAutoSubmitToggle}
+                onSubmit={handleSubmit}
+                onClear={handleClear}
+              />
+            ) : mode === 'dead' ? (
+              <DeadForm
+                statusMsg={statusMsg}
+                statusKind={statusKind}
+                canSubmit={canSubmit}
+                hint={hint}
+                exactLocation={exactLocation}
+                autoSubmit={autoSubmit}
+                autoCountdown={autoCountdown}
+                cloudCheck={cloudCheck}
+                blinkFrame={blinkFrame}
+                onHintChange={handleHintChange}
+                onAutoSubmitToggle={handleAutoSubmitToggle}
+                onSubmit={handleSubmit}
+                onClear={handleClear}
+              />
+            ) : (
+              <ReportForm
+                hours={hours}
+                minutes={minutes}
+                hint={hint}
+                statusMsg={statusMsg}
+                statusKind={statusKind}
+                hasPixel={hasPixel}
+                canSubmit={canSubmit}
+                onHoursChange={setHours}
+                onMinutesChange={setMinutes}
+                onHintChange={handleHintChange}
+                autoScan={autoScan}
+                isScanning={isScanning}
+                onScanDialog={handleScanDialog}
+                onAutoScanToggle={handleAutoScanToggle}
+                autoSubmit={autoSubmit}
+                autoCountdown={autoCountdown}
+                cloudCheck={cloudCheck}
+                blinkFrame={blinkFrame}
+                onAutoSubmitToggle={handleAutoSubmitToggle}
+                onSubmit={handleSubmit}
+                onClear={handleClear}
+              />
+            )}
+          </>
         ) : (
-          <ReportForm
-            hours={hours}
-            minutes={minutes}
-            hint={hint}
-            statusMsg={statusMsg}
-            statusKind={statusKind}
-            hasPixel={hasPixel}
-            canSubmit={canSubmit}
-            onHoursChange={setHours}
-            onMinutesChange={setMinutes}
-            onHintChange={handleHintChange}
-            autoScan={autoScan}
-            isScanning={isScanning}
-            onScanDialog={handleScanDialog}
-            onAutoScanToggle={handleAutoScanToggle}
-            autoSubmit={autoSubmit}
-            autoCountdown={autoCountdown}
-            cloudCheck={cloudCheck}
-            blinkFrame={blinkFrame}
-            onAutoSubmitToggle={handleAutoSubmitToggle}
-            onSubmit={handleSubmit}
-            onClear={handleClear}
-          />
+          <NotConnectedPrompt />
         )}
 
         {import.meta.env.MODE === 'development' && <DebugPanel />}

--- a/alt1-plugin/src/components/NotConnectedPrompt.tsx
+++ b/alt1-plugin/src/components/NotConnectedPrompt.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { CircleQuestionMark, CircleX } from 'lucide-react';
+
+export function NotConnectedPrompt() {
+  const [learnMore, setLearnMore] = useState(false);
+  const dashboardUrl = `${window.location.origin}/`;
+
+  return (
+    <div className="px-3 py-4 flex flex-col gap-3">
+      <p className="text-sm text-muted-foreground text-center">
+        To start scouting,<br />
+        <a
+          href={dashboardUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-foreground underline underline-offset-2"
+        >
+          connect to Ectotrees
+        </a>
+        .
+      </p>
+
+      <div className={`flex flex-col gap-3 rounded p-3 border ${learnMore ? 'border-cyan-400-a50' : 'border-transparent'}`}>
+        <button
+          onClick={() => setLearnMore(v => !v)}
+          className="mx-auto flex items-center text-muted-foreground"
+        >
+          {learnMore ? <CircleX size={14} /> : <CircleQuestionMark size={14} />}
+        </button>
+        {learnMore && (
+          <p className="text-xs text-muted-foreground">
+            From the Ectotrees dashboard, find the cyan box containing your 12-digit{' '}
+            <span className="text-foreground">identity code</span>{' '}
+            then copy and paste it into the input above.<br/><br/>
+            No code yet? Click the{' '}
+            <span className="text-foreground">Link with Alt1</span>{' '}
+            button or join a managed session to generate an identity code.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/alt1-plugin/src/components/SessionPanel.tsx
+++ b/alt1-plugin/src/components/SessionPanel.tsx
@@ -196,7 +196,7 @@ export function SessionPanel({
       <div className="flex items-center gap-1.5">
         <input
           type="text"
-          placeholder="Invite code"
+          placeholder="Identity code"
           autoComplete="off"
           spellCheck={false}
           value={inputCode}

--- a/alt1-plugin/src/index.css
+++ b/alt1-plugin/src/index.css
@@ -22,6 +22,9 @@
   --color-green-400-a20: rgba(5, 223, 114, 0.20);
   --color-green-400-a25: rgba(5, 223, 114, 0.25);
   --color-green-400-a50: rgba(5, 223, 114, 0.50);
+  --color-cyan-400:     #22d3ee;
+  --color-cyan-400-a20: rgba(34, 211, 238, 0.20);
+  --color-cyan-400-a50: rgba(34, 211, 238, 0.50);
   --color-gray-300:      #d1d5db;
 
   --color-border: hsl(var(--border));


### PR DESCRIPTION
Replace the scouting form area with a `NotConnectedPrompt` when the session `status` is not `'connected'`. The prompt links back to the dashboard and includes a collapsible help section explaining how to obtain and enter the 12-digit identity code.

- Add `NotConnectedPrompt` component with toggle-able "learn more" panel
- Gate `WorldInput`, `ModeNav`, and all mode forms behind `status === 'connected'`
- Rename "Invite code" placeholder to "Identity code" in `SessionPanel`
- Add `cyan-400` alpha token variants to `alt1-plugin/src/index.css`